### PR TITLE
Do not run flowzone when the PR is closed without merging.

### DIFF
--- a/.github/workflows/flowzone.yml
+++ b/.github/workflows/flowzone.yml
@@ -2,7 +2,11 @@ name: Flowzone
 
 on:
   pull_request:
-    types: [opened, synchronize, closed]
+    types: [opened, synchronize]
+    branches:
+      - "main"
+      - "master"
+  push:
     branches:
       - "main"
       - "master"


### PR DESCRIPTION
This avoids running cleanup and publish when the PR is closed but is not merged.  The master branch is protected so pushes to the master should only happen through merged PRs.

Change-type: patch
Signed-off-by: Carlo Miguel F. Cruz <carloc@balena.io>