### PR TITLE
 Instruct how to get admin events on personal calendar

### DIFF
--- a/docs/tooling/google-calendar.md
+++ b/docs/tooling/google-calendar.md
@@ -4,9 +4,60 @@ Since all scheduled meetings, presentations, and discussions are mainly done rem
 
 Part of your daily routine may include meetings with other team members, the team that you’re part of, customers, and more. Also, you will often be required to start a meeting and invite some of your colleagues. You should always check your calendar and other team members’ calendar before inviting someone to a call or before scheduling a new call, to make sure it doesn’t overlap with other important calls. 
 
-Before we proceed, please make sure that you have access to the company calendar; [Balena Admin calendar](https://calendar.google.com/calendar/embed?src=admin%40balena.io&ctz=Europe%2FAthens) (ownership of admin@balena.io), [Balena Social Calendar](https://calendar.google.com/calendar/embed?src=balena.io_alenh700u1kual2pk9j5n4ujdk%40group.calendar.google.com&ctz=Europe%2FAthens), [Calamari Calendar](https://calendar.google.com/calendar/embed?src=resin.io_6hoecbna6i1e75mft25tqop1uo%40group.calendar.google.com&ctz=Europe%2FAthens) and if applicable to you, the [Support calendar](https://calendar.google.com/calendar/embed?src=resin.io_2klk2f26ivo04qq5ktlkva1neg%40group.calendar.google.com&ctz=Europe%2FAthens). Each calendar has a plus icon on the bottom right, allowing you to add it to your individual calendar.
+## Access balena's company calendars
+
+Before we proceed, please make sure that you have access to the company calendars; 
+  - [Balena Admin calendar](https://calendar.google.com/calendar/embed?src=admin%40balena.io&ctz=Europe%2FAthens) (ownership of admin@balena.io) 
+  - [Balena Social Calendar](https://calendar.google.com/calendar/embed?src=balena.io_alenh700u1kual2pk9j5n4ujdk%40group.calendar.google.com&ctz=Europe%2FAthens) 
+  - [Calamari Calendar](https://calendar.google.com/calendar/embed?src=resin.io_6hoecbna6i1e75mft25tqop1uo%40group.calendar.google.com&ctz=Europe%2FAthens) 
+  - [Support calendar](https://calendar.google.com/calendar/embed?src=resin.io_2klk2f26ivo04qq5ktlkva1neg%40group.calendar.google.com&ctz=Europe%2FAthens)(if applicable to you.) 
+
+:::tip 
+
+Each calendar has a plus icon on the bottom right, allowing you to add it to your individual calendar. Keep in mind you must be signed into your balena issued google account first when adding a calendar.
+
+:::
 
 After you have been onboarded, if you noticed you do not have access to any of the following calendars you can request access by pinging @@operations in Jellyfish and use the `#access`. Please note that all calls are included in the Balena Admin calendar. In addition, bear in mind that the admin calendar follows GMT (UTC +0) London time zone.
+
+## Set up company-wide meetings on your calendar
+
+When you have access to the company wide calendars, you will be able to invite yourself to weekly meetings from these calendars that you want to attend. By inviting yourself, the event will then populate to your own calendar as well. This is recommended so you can get updates in real time from the team and so you can approve or decline meetings from your calendar without making any company wide calendar changes accidentally. 😉 
+
+_For new hires, if you are not sure which meetings you will be attending regularly yet, not to worry, this can be done at a later time or when needed as well._
+
+### To invite yourself to a company wide balena calendar event so that you can get notifications about it ###
+
+1. Click on the event you would like to invite yourself to. 
+2. Click on "edit event" (pencil icon).
+3. On the right you will see a field to "add guests." Click on the field.
+4. Begin to type in your name and then select your name from the drop down. 
+5. Click "save." You will then be given the option to invite yourself for "this event," "this and following events," or "all events. 
+6. Click on the option you would like and then click "ok." You will see the event populate on your calendar shortly.
+
+Please be sure any changes made to the calendar event are from your personal calendar moving forward. Changes to the company wide calendar event can cause changes for your teammate's calendars as well. Also, please note that these same steps can be used to add a team mate to a company wide event. 😃
+
+### To remove yourself from a company wide balena calendar event so that you aren't notified about it ###
+
+If you change your mind down the line about an ongoing event and wish to then remove yourself
+
+1. Click on the event you would like to remove yourself from. 
+2. Click on "edit event" (pencil icon).
+3. On the right you will see a list of guests. 
+4. Scroll down the list until you come to your name. When you hover over your name you will see a "X". 
+5. Click the "X". This will remove your name from the guest list. 
+6. Click "save". You will  be given the option to make the change for "this event," "this and following events," or "all events". 
+7. Click on the option you would like and then click "ok." You will no longer see the event reflected on your personal calendar.
+
+### Changes to calendar notifications  ###
+
+Once you have added the events you want to your calendar, you can add, remove, or change the frequency of notifications from the company wide calendars.
+
+  To remove notifications from a balena company calendar:
+  1. Go to the balena company calendars on the left hand sidebar of your calendar.
+  2. Hover over the calendar of your choice. You should see the operations icon (three dot menu).
+  3. Click the operations icon. Then click on "settings."
+  4. Scroll down to "Event Notifications." From there you can add, remove, and change the frequency of notifications).
 
 ## See a colleague’s calendar
 Let’s say you need to schedule a call where one of your colleagues needs to be invited but you’re not sure whether they have any open slots. One solution would be to ask them directly about availability. This would mean that you both will need to stop what you’re doing and work on scheduling that call.


### PR DESCRIPTION
Added instructions in the handbook on how to add balena company wide events to one's personal calendar, how to remove oneself from an event, and how to add/remove notifications from company wide calendars.

Also, converted some text to bullet points and separated some of the sections with headings to make it easier to follow. 

Change-type: minor