### PR TITLE
Changes; HW refresh, policy name, furniture budget.md

### DIFF
--- a/docs/policies/home-office-and-equipment-policy.md
+++ b/docs/policies/home-office-and-equipment-policy.md
@@ -1,6 +1,6 @@
 # Productivity and Company Equipment Policy
 
-While working at balena, we want to give you the tools to work as comfortably and productively as possible. We offer all new team members $3,300 USD for hardware and home office equipment. This is to be treated as the hard limit of the amount you can use when you join balena depending on your needs. You are able to pick the hardware you’d like to use (see the Purchasing Information section below).
+While working at balena, we want to give you the tools to work as comfortably and productively as possible. We offer all new team members $2,500 USD for hardware and home office equipment. This is to be treated as the hard limit of the amount you can use when you join balena depending on your needs. You are able to pick the hardware you’d like to use (see the Purchasing Information section below).
 
 You will receive an e-mail with ordering information. We have company accounts with major, worldwide vendors (Apple, Dell, Amazon etc.) so you can just send us links from those vendors for the products you would like. If you feel that the worldwide vendors would cause unnecessary delays or customs fees, please talk to us about better local options.
 

--- a/docs/policies/home-office-and-equipment-policy.md
+++ b/docs/policies/home-office-and-equipment-policy.md
@@ -1,53 +1,53 @@
-# Home Office and Equipment Policy
+# Productivity and Company Equipment Policy
 
-While working at balena, we want to give you the tools to work as comfortably and productively as possible. We offer all new team members the equivalent of a $3,300 USD budget for hardware and home office equipment. You are able to pick the hardware you’d like to use (see the Purchasing Information section below).
+While working at balena, we want to give you the tools to work as comfortably and productively as possible. We offer all new team members $3,300 USD for hardware and home office equipment. This is to be treated as the hard limit of the amount you can use when you join balena depending on your needs. You are able to pick the hardware you’d like to use (see the Purchasing Information section below).
 
 You will receive an e-mail with ordering information. We have company accounts with major, worldwide vendors (Apple, Dell, Amazon etc.) so you can just send us links from those vendors for the products you would like. If you feel that the worldwide vendors would cause unnecessary delays or customs fees, please talk to us about better local options.
 
 :::note
 
-Note that the hardware you purchase on this budget is owned by balena. At termination it will either be returned, may be purchased from balena, or (depending on the current value and age) may be given to the team member.
+Note that the hardware you purchase on this budget is owned by balena. At termination, it will either be returned to balena or it can be purchased by the team member. 
 
 :::
+
 ## Purchasing Information
 
-Your purchase should include a laptop with the necessary specifications to run your job-related software and be future-proof for at least three years. (Please do not purchase a desktop computer so that you can travel and work in the occasion of a summit/minisummit.).
+Your purchase should include a laptop with the necessary specifications to run your job-related software and be future-proof for at least three years. (Please do not purchase a desktop computer so that you can travel and work on the occasion of a summit/mini-summit.).
 
+Apple, Dell, and Lenovo are three laptop brands that are recommended. Avoid brands that provide custom laptop builds, such as System76 and TUXEDO, as they are unreliable in our experience. Choose at least 16 GB of RAM, but more than 16 GB is recommended (for devs). Also, choose at least 500 GB of hard drive space.  
+Specifically, if you choose an Apple laptop, choose the most recent model (note that Macbook Pro has more battery life than the Macbook Air). For Dell, we recommend the XPS models, as they are high-end, and for Lenovo, we recommend a laptop from the ThinkPad X1 series.  
+Please take the time to choose carefully, as we do not recommend adding additional RAM or hard drives later. 
 
-Apple, Dell, and Lenovo are three laptop brands that are recommended. Avoid brands that provide custom laptop builds, such as System76 and TUXEDO, as they are unreliable in our experience. Choose at least 16 GB of RAM, but more than 16 GB is recommended (for devs). Also, choose at least 500 GB of hard drive space.
-Specifically, if you choose an Apple laptop, choose the most recent model (note that  Macbook Pro has more battery life than the Macbook Air). For Dell, we recommend the XPS models, as they are high-end , and for Lenovo, we recommend a laptop from the ThinkPad X1 series. 
-Please take the time to choose carefully, as we do not recommend adding additional RAM or hard drives later. Keep in mind that while opening a new laptop does not "itself" void the warranty, any damage caused by opening it will.
-
-
-If you do not already have high quality noise canceling headphones (like Jabra Evolve 80 or Bose 700) you can use for work, please purchase some within the hardware budget. Having good audio quality is very important in our communications.
+If you do not already have high-quality noise-canceling headphones (like Jabra Evolve 80 or Bose 700) you can use for work, please purchase some within the hardware budget. Having good audio quality is very important in our communications.
 
 Other items you could buy with your hardware budget include: monitor, docking station, keyboard, mouse, laptop stand, power supply & extension.
 
-As we are a distributed company, all team members can also use up to $500 USD of their hardware budget for their home office (desks, computer chairs, etc.).
-
 If you’re not sure what to purchase, take a look at [recommendations from your coworkers](https://docs.google.com/spreadsheets/d/1U1dkMP_fuDMLNqvVW5nQwsh3f8l-ZX1Y3Wp_LlSE5yc/edit?resourcekey#gid=25100414). If it helps in planning your needs, here is a [list of the software](https://docs.google.com/forms/d/1o1Vf7h2rGKwZt7jI1nlrZb60I2TureLSqjNJRDYkbpA/viewanalytics) that your coworkers use.
 
-Please send a [hashtag order request](../team/ordering-hashtag-order-process.md) in a Jellyfish thread.
+Please send a [hashtag order request](../team/ordering-hashtag-order-process.md) in a Zulip stream.
 
 If you aren’t sure if something is included in the budget, let us know!
 
-## 3 Year Laptop/Hardware Refresh
+## Laptop Refresh
 
-Team member laptops can be refreshed after 3 years of use. Please reach out to TeamOS around your 3 year anniversary if you’d like to use an additional $3,300 USD budget to order hardware.
+We understand that your equipment might need to be repaired, upgraded, or replaced and we are here to support you to do so and optimize for productivity. 
 
-## Replacing Hardware Before the 3 Year Anniversary
+*   If your laptop needs to be repaired, please find an estimate of the cost and wait time and reach out to TeamOS. You should also confirm whether the laptop is under warranty. Note that tampering with a laptop under warranty might void the warranty which can incur extra costs that the team member can be called to cover. 
+*   If you ever find that your laptop is not capable of what you need, our offices have an inventory of used laptops that are often in great condition and relatively new. Contact TeamOS to see if we have something that suits your needs.
+*   If you need to replace any of your peripherals or need additional hardware to increase your productivity at balena, please reach out to TeamOS to discuss. 
+*   If your use case is not covered by the above bullet points, we will work together on ordering a new laptop for you. 
 
-Our offices have an inventory of used laptops. If you ever find that your laptop is not capable of what you need please contact TeamOS first to see if they have something that is.
+What we would not consider a good reason for a laptop refresh and/or purchasing a new one. 
 
-If you need to replace any of your hardware or need additional hardware to increase your productivity at balena, please reach out to TeamOS.
+*   Replacing your fully functional laptop with the latest Model
+*   Deciding to switch from Apple to Windows
+*   Having a scratch on your laptop's lid
 
-If your laptop needs to be repaired, please find an estimate of the cost. If it is under 20% of the laptop price, please have it repaired and expense the cost. If the cost is too high (or if the wait time is too long), please reach out to TeamOS for a used laptop. You should also confirm whether the laptop is under warranty.
+Please treat the above as a live and work-in-progress guide which should expand as you continue to communicate your needs and feedback to TeamOS. We are here to support you maximize your productivity :)
 
+## What do we do with the old laptop?
 
-
-## What do we do with our old laptop?
-
-If a laptop is older than 3 years (and replaced by new models) and is valued at over $500 USD, it can either be purchased by the team member or returned to balena. If it is currently valued at under $500, it will often be given to the team member.
+It can either be purchased by the team member or returned to balena. Bear in mind that the company follows specific accounting practices to define the value and price of a laptop which often sets the price lower than what you can find on the market. 
 
 ## Your Recommendations
 


### PR DESCRIPTION
- removed the $500 to be used on office furniture
- removed the 3year budget HW refresh and replaced it with guidance to replace/refresh your laptop when and if needed
- added info around warranty; tampering with a laptop under warranty and extra costs
- removed the option to give the team member their laptop beyond the 3years mark for free
- changed policy name from 'Home Office and Equipment Policy' to 'Productivity and Company Equipment Policy'
- replaced Jellyfish with Zulip for #order
- various minor changes in wording to add clarity

Change-type: major
Signed-off-by: NatasaKyetou <natass@balena.io>