### PR TITLE
Revert "Add GitHub self-serve issue ops to access requests"

### DIFF
--- a/docs/access-requests/README.md
+++ b/docs/access-requests/README.md
@@ -1,10 +1,8 @@
 # Access Requests
 
-On your first day, you'll be getting access to a list of services, what we call [the basic tools](../onboarding/basic-tool-setup.md). These services should be all you need to start working and discovering more about balena. However, as the days go by and you dig deeper into your role and into the relevant workflows, you'll discover more services that you may need access to.
+On your first day, you'll be getting access to a list of services, what we call [the basic tools](../onboarding/basic-tool-setup.md). These services should be all you need to start working and discovering more about balena. However, as the days go by and you dig deeper into your role and into the relevant workflows, you'll discover more services that you may need access to. 
 
-If you need temporary administrator access to a GitHub organization or repository, you can self-serve the request via <https://github.com/balenaltd/admins/issues/new/choose>.
-
-For anything else that's access-related, you should be using #access in Zulip to request it. 
+Whenever you need access to a service or anything else that's access-related, you should be using #access in Zulip to request it. 
 Every time you request access to a service, your message should include 3 basic points:
 - #access
 - service information (ie service name, org, team) - be as specific as possible but don't worry if you don't have all the information, we'll figure it out together


### PR DESCRIPTION
This reverts commit a42926daa066600632eb37609a0184c4ef038062.

The use of issue ops is being restricted due to security concerns, so we can remove it from the handbook for now.

Change-type: patch